### PR TITLE
Refactorar inserção de nó em arquivo

### DIFF
--- a/include/arquivo.h
+++ b/include/arquivo.h
@@ -78,6 +78,24 @@ CABECALHO* le_cabecalho(FILE* arquivo);
 int escreve_cabecalho(FILE* arquivo, const CABECALHO* cabecalho);
 
 /**
+ * @brief Escreve um nó da árvore na posição especificada do arquivo.
+ *
+ * Posiciona o ponteiro do arquivo na posição correta (após o cabeçalho) e
+ * grava o nó informado.
+ *
+ * @param[in,out] arquivo Ponteiro para arquivo aberto em modo escrita.
+ * @param[in] no Ponteiro para o nó que será escrito.
+ * @param[in] posicao Índice no arquivo onde o nó será escrito.
+ * @return Código de erro: SUCESSO (0) ou código negativo em caso de falha.
+ *
+ * @pre `arquivo` e `no` devem ser diferentes de NULL.
+ * @pre `posicao` deve ser válida (não negativa).
+ *
+ * @post O nó será escrito na posição indicada do arquivo.
+ */
+int escrever_no(FILE* arquivo, const NO_ARVORE* no, const int posicao);
+
+/**
  * @brief Insere um nó na árvore no arquivo, utilizando lista livre se disponível.
  *
  * Se existir posição livre (removida anteriormente), reutiliza-a; caso contrário,
@@ -85,14 +103,16 @@ int escreve_cabecalho(FILE* arquivo, const CABECALHO* cabecalho);
  *
  * @param[in,out] arquivo Ponteiro para arquivo aberto para leitura e escrita.
  * @param[in] no_arvore Ponteiro para o nó a ser inserido.
+ * @param[out] posicao_inserida Ponteiro utilizado para informar qual posição nó foi inserido
  * @return Código de retorno: SUCESSO (0) ou erro específico.
  *
  * @pre `arquivo` e `no_arvore` não podem ser NULL.
  * @pre Arquivo deve conter cabeçalho válido.
  *
  * @post Nó inserido no arquivo, cabeçalho atualizado.
+ * @post Valor de posicao_inserida é alterado, refletindo a posição em que o nó foi inserido
  */
-int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore);
+int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore, int* posicao_inserida);
 
 /**
  * @brief Remove um nó da árvore no arquivo e o adiciona à lista livre.

--- a/src/arquivo.c
+++ b/src/arquivo.c
@@ -118,7 +118,7 @@ NO_ARVORE* ler_no_arquivo(FILE* arquivo, const int posicao) {
  *
  * @post O nó será escrito na posição indicada do arquivo.
  */
-static int escrever_no(FILE* arquivo, const NO_ARVORE* no, const int posicao) {
+int escrever_no(FILE* arquivo, const NO_ARVORE* no, const int posicao) {
         if (arquivo == NULL) return ERRO_ARQUIVO_NULO;
         if (no == NULL) return ERRO_NO_NULO;
 
@@ -137,14 +137,16 @@ static int escrever_no(FILE* arquivo, const NO_ARVORE* no, const int posicao) {
  *
  * @param[in,out] arquivo Ponteiro para arquivo aberto para leitura e escrita.
  * @param[in] no_arvore Ponteiro para o nó a ser inserido.
+ * @param[out] posicao_inserida Ponteiro utilizado para informar qual posição nó foi inserido
  * @return Código de retorno: SUCESSO (0) ou erro específico.
  *
  * @pre `arquivo` e `no_arvore` não podem ser NULL.
  * @pre Arquivo deve conter cabeçalho válido.
  *
  * @post Nó inserido no arquivo, cabeçalho atualizado.
+ * @post Valor de posicao_inserida é alterado, refletindo a posição em que o nó foi inserido
  */
-int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore) {
+int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore, int* posicao_inserida) {
         if (arquivo == NULL) return ERRO_ARQUIVO_NULO;
 
         if (no_arvore == NULL) return ERRO_NO_NULO;
@@ -166,6 +168,8 @@ int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore) {
                         return r;
                 }
 
+                *posicao_inserida = cabecalho->livre;
+
                 cabecalho->livre = no_livre->filho_esquerdo;
                 free(no_livre);
         } else {
@@ -174,6 +178,8 @@ int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore) {
                         free(cabecalho);
                         return r;
                 }
+
+                *posicao_inserida = cabecalho->topo;
 
                 cabecalho->topo++;
         }

--- a/tests/test_arquivo.c
+++ b/tests/test_arquivo.c
@@ -197,8 +197,11 @@ static void test_inserir_no_valido_sem_lista_livre(void** state) {
         no.filho_direito = -1;
         no.filho_esquerdo = -1;
 
-        int r = inserir_no_arquivo(arquivo, &no);
+        int posicao_inserido = -1;
+
+        int r = inserir_no_arquivo(arquivo, &no, &posicao_inserido);
         assert_int_equal(r, SUCESSO);
+        assert_int_equal(posicao_inserido, 0);
 
         CABECALHO cabecalho = {0};
         fseek(arquivo, 0, SEEK_SET);
@@ -275,8 +278,11 @@ static void test_inserir_no_valido_com_lista_livre(void** state) {
         no.filho_direito = -1;
         no.filho_esquerdo = -1;
 
-        int r = inserir_no_arquivo(arquivo, &no);
+        int posicao_inserido = -1;
+
+        int r = inserir_no_arquivo(arquivo, &no, &posicao_inserido);
         assert_int_equal(r, SUCESSO);
+        assert_int_equal(posicao_inserido, 0);
 
         CABECALHO cabecalho = {0};
         fseek(arquivo, 0, SEEK_SET);
@@ -319,7 +325,9 @@ static void test_ler_no_arquivo_valido(void** state) {
         no.livro = livro;
         no.filho_direito = -1;
         no.filho_esquerdo = -1;
-        inserir_no_arquivo(arquivo, &no);
+
+        int posicao_inserido = -1;
+        inserir_no_arquivo(arquivo, &no, &posicao_inserido);
 
         NO_ARVORE* no_lido = ler_no_arquivo(arquivo, 0);
         assert_non_null(no_lido);
@@ -341,7 +349,9 @@ static void test_remover_no_arquivo_valido(void** state) {
         no.filho_direito = -1;
         no.filho_esquerdo = -1;
 
-        inserir_no_arquivo(arquivo, &no);
+        int posicao_inserido = -1;
+
+        inserir_no_arquivo(arquivo, &no, &posicao_inserido);
         int r = remover_no_arquivo(arquivo, 0);
         assert_int_equal(r, SUCESSO);
 


### PR DESCRIPTION
## O que este PR faz?
- Refatora `inserir_no_arquivo`, incluindo um novo parâmetro que retorna a posição em que o nó foi inserido.
- Atualiza testes unitários para refletir o refactor de `inserir_no_arquivo`.
- Torna a função `escrever_no` pública (remove static).
- Atualiza documentação para refletir as alterações.

## Por que isso é necessário?
É necessário para criar a função de inserir nó na árvore.

## Como testar?
- Compilar com `make test`.
- Executar com `valgrind ./build/tests`.
- Compilar documentação com `doxygen Doxyfile`. 

## Arquivos importantes alterados
- `arquivo.h` e `arquivo.c`.
- `test_arquivo.c`.