### PR TITLE
Adiciona busca de nó em árvore binaria e corrige parâmetro incorreto

### DIFF
--- a/include/arquivo.h
+++ b/include/arquivo.h
@@ -129,7 +129,7 @@ int inserir_no_arquivo(FILE* arquivo, const NO_ARVORE* no_arvore, int* posicao_i
  *
  * @post Nó removido é marcado como livre e lista livre atualizada no cabeçalho.
  */
-int remover_no_arquivo(FILE* arquivo, const int codigo);
+int remover_no_arquivo(FILE* arquivo, const int posicao);
 
 /**
  * @brief Lê um nó da árvore do arquivo na posição especificada.

--- a/include/arvore.h
+++ b/include/arvore.h
@@ -37,9 +37,9 @@ typedef struct NO_ARVORE {
  * @brief Indica se um nó é filho esquerdo, direito ou inválido.
  */
 typedef enum {
-    LADO_INVALIDO = -1, /**< Valor inválido para lado do filho */
-    LADO_ESQUERDO = 0,  /**< Nó é filho esquerdo */
-    LADO_DIREITO = 1    /**< Nó é filho direito */
+        LADO_INVALIDO = -1, /**< Valor inválido para lado do filho */
+        LADO_ESQUERDO = 0,  /**< Nó é filho esquerdo */
+        LADO_DIREITO = 1    /**< Nó é filho direito */
 } lado_filho;
 
 /**
@@ -50,11 +50,11 @@ typedef enum {
  * o nó pai e sua posição, e o lado do nó em relação ao pai.
  */
 typedef struct {
-    NO_ARVORE* no;       /**< Ponteiro para o nó encontrado (deve ser liberado pelo usuário) */
-    int posicao_no;      /**< Posição no arquivo do nó encontrado */
-    NO_ARVORE* pai;      /**< Ponteiro para o nó pai (pode ser NULL se o nó for raiz) */
-    int posicao_pai;     /**< Posição no arquivo do nó pai */
-    lado_filho lado;     /**< Indica se o nó é filho esquerdo ou direito do pai */
+        NO_ARVORE* no;   /**< Ponteiro para o nó encontrado (deve ser liberado pelo usuário) */
+        int posicao_no;  /**< Posição no arquivo do nó encontrado */
+        NO_ARVORE* pai;  /**< Ponteiro para o nó pai (pode ser NULL se o nó for raiz) */
+        int posicao_pai; /**< Posição no arquivo do nó pai */
+        lado_filho lado; /**< Indica se o nó é filho esquerdo ou direito do pai */
 } RESULTADO_BUSCA;
 
 /**

--- a/include/arvore.h
+++ b/include/arvore.h
@@ -6,13 +6,16 @@
 #ifndef ARVORE_BINARIA_H
 #define ARVORE_BINARIA_H
 
+#include <stddef.h>
+#include <stdio.h>
+
 #include "livro.h"
 
 /**
  * Estrutura que representa um nó em uma árvore binária,
  * armazenando um livro como dado.
  */
-typedef struct {
+typedef struct NO_ARVORE {
         /**
          * Estrutura que representa um livro no registro.
          */
@@ -28,5 +31,52 @@ typedef struct {
          */
         int filho_direito;
 } NO_ARVORE;
+
+/**
+ * @enum lado_filho
+ * @brief Indica se um nó é filho esquerdo, direito ou inválido.
+ */
+typedef enum {
+    LADO_INVALIDO = -1, /**< Valor inválido para lado do filho */
+    LADO_ESQUERDO = 0,  /**< Nó é filho esquerdo */
+    LADO_DIREITO = 1    /**< Nó é filho direito */
+} lado_filho;
+
+/**
+ * @struct RESULTADO_BUSCA
+ * @brief Estrutura que armazena o resultado da busca em uma árvore binária.
+ *
+ * Contém o nó encontrado, sua posição no arquivo,
+ * o nó pai e sua posição, e o lado do nó em relação ao pai.
+ */
+typedef struct {
+    NO_ARVORE* no;       /**< Ponteiro para o nó encontrado (deve ser liberado pelo usuário) */
+    int posicao_no;      /**< Posição no arquivo do nó encontrado */
+    NO_ARVORE* pai;      /**< Ponteiro para o nó pai (pode ser NULL se o nó for raiz) */
+    int posicao_pai;     /**< Posição no arquivo do nó pai */
+    lado_filho lado;     /**< Indica se o nó é filho esquerdo ou direito do pai */
+} RESULTADO_BUSCA;
+
+/**
+ * @brief Busca um nó na árvore binária persistida em arquivo pelo código do livro.
+ *
+ * Esta função realiza a busca de um nó que contenha um livro com o código
+ * especificado, retornando informações detalhadas sobre o nó encontrado, seu pai,
+ * suas posições no arquivo e o lado do nó em relação ao pai.
+ *
+ * @param[in] arquivo Ponteiro para o arquivo que contém a árvore binária.
+ * @param[in] codigo Código do livro a ser buscado.
+ * @param[out] resultado Ponteiro para estrutura que será preenchida com os dados da busca.
+ *
+ * @return Código de status da operação:
+ * - SUCESSO (0) se o nó foi encontrado com sucesso.
+ * - ERRO_ARQUIVO_NULO se o ponteiro do arquivo é NULL.
+ * - ERRO_CABECALHO_NULO se não foi possível ler o cabeçalho do arquivo.
+ * - ERRO_NO_NULO se a árvore estiver vazia ou o nó não for encontrado.
+ *
+ * @note Os ponteiros no e pai dentro de @p resultado são alocados dinamicamente
+ * e devem ser liberados pelo usuário após o uso.
+ */
+int buscar_no_arvore(FILE* arquivo, size_t codigo, RESULTADO_BUSCA* resultado);
 
 #endif

--- a/include/livro.h
+++ b/include/livro.h
@@ -13,6 +13,14 @@
 #define MAX_EDITORA 50  //!< Tamanho máximo do campo "editora"
 
 /**
+ * @brief Declaração antecipada do tipo NO_ARVORE
+ *
+ * Usada para evitar include recursivo entre `livro.h` e `arvore.h`
+ * Veja a documentação completa em @ref NO_ARVORE "arvore.h"
+ */
+typedef struct NO_ARVORE NO_ARVORE;
+
+/**
  * Estrutura que representa um livro na árvore binária.
  */
 typedef struct {

--- a/src/arvore.c
+++ b/src/arvore.c
@@ -1,0 +1,87 @@
+#include "../include/arvore.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/arquivo.h"
+#include "../include/erros.h"
+#include "../include/livro.h"
+
+/**
+ * @brief Busca um nó na árvore binária persistida em arquivo pelo código do livro.
+ *
+ * Esta função realiza a busca de um nó que contenha um livro com o código
+ * especificado, retornando informações detalhadas sobre o nó encontrado, seu pai,
+ * suas posições no arquivo e o lado do nó em relação ao pai.
+ *
+ * @param[in] arquivo Ponteiro para o arquivo que contém a árvore binária.
+ * @param[in] codigo Código do livro a ser buscado.
+ * @param[out] resultado Ponteiro para estrutura que será preenchida com os dados da busca.
+ *
+ * @return Código de status da operação:
+ * - SUCESSO (0) se o nó foi encontrado com sucesso.
+ * - ERRO_ARQUIVO_NULO se o ponteiro do arquivo é NULL.
+ * - ERRO_CABECALHO_NULO se não foi possível ler o cabeçalho do arquivo.
+ * - ERRO_NO_NULO se a árvore estiver vazia ou o nó não for encontrado.
+ *
+ * @note Os ponteiros no e pai dentro de @p resultado são alocados dinamicamente
+ * e devem ser liberados pelo usuário após o uso.
+ */
+int buscar_no_arvore(FILE* arquivo, size_t codigo, RESULTADO_BUSCA* resultado) {
+        if (arquivo == NULL) return ERRO_ARQUIVO_NULO;
+
+        CABECALHO* cabecalho = le_cabecalho(arquivo);
+        if (cabecalho == NULL) return ERRO_CABECALHO_NULO;
+        if (cabecalho->raiz == POSICAO_INVALIDA) return ERRO_NO_NULO;
+
+        int posicao_atual = cabecalho->raiz;
+        int posicao_pai = POSICAO_INVALIDA;
+
+        NO_ARVORE* no_atual = NULL;
+        NO_ARVORE* no_pai = NULL;
+
+        lado_filho lado = LADO_INVALIDO;
+
+        while (posicao_atual != POSICAO_INVALIDA) {
+                no_atual = ler_no_arquivo(arquivo, posicao_atual);
+                if (no_atual == NULL) {
+                        free(cabecalho);
+                        free(no_pai);
+                        return ERRO_NO_NULO;
+                }
+
+                if (no_atual->livro.codigo == codigo) break;
+
+                posicao_pai = posicao_atual;
+
+                // libera nó pai antes de atualizar
+                free(no_pai);
+                no_pai = no_atual;
+
+                if (codigo < no_atual->livro.codigo) {
+                        posicao_atual = no_atual->filho_esquerdo;
+                        lado = LADO_ESQUERDO;
+                } else {
+                        posicao_atual = no_atual->filho_direito;
+                        lado = LADO_DIREITO;
+                }
+        }
+
+        if (posicao_atual == POSICAO_INVALIDA) {
+                free(cabecalho);
+                free(no_atual);
+                free(no_pai);
+                return ERRO_NO_NULO;
+        }
+
+        resultado->no = no_atual;
+        resultado->pai = no_pai;
+        resultado->posicao_no = posicao_atual;
+        resultado->posicao_pai = posicao_pai;
+        resultado->lado = lado;
+
+        free(cabecalho);
+
+        return SUCESSO;
+}


### PR DESCRIPTION
## O que este PR faz?
- Altera parâmetro da função `remover_no_arquivo`, que estava diferente nos arquivos .h e .c.
- Adiciona a função `buscar_no_arvore` e documenta ela.
- Adiciona declaração antecipada de `NO_ARVORE` em `livro.h` para evitar include recursivo.
- Cria o enum `lado_filho` que serve para indicar se um nó é filho esquerdo ou direito do nó pai.
- Cria estrutura `RESULTADO_BUSCA`, que agrupa todas as informações retornadas por `buscar_no_arquivo`.

## Por que isso é necessário?
Evita código duplicado em outras funções.